### PR TITLE
Fix docs generation integration test (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - Fix test related to preventing coercion of boolean values (True,False) to numeric values (0,1) in query results ([#58](https://github.com/dbt-labs/dbt-redshift/blob/1.0.latest/CHANGELOG.md))
+- Add unique\_id field to docs generation test catalogs; a follow-on PR to core PR ([#4168](https://github.com/dbt-labs/dbt-core/pull/4618)) and core PR ([#4701](https://github.com/dbt-labs/dbt-core/pull/4701))
 
 ## dbt-redshift 1.0.0 (December 3, 2021)
 

--- a/tests/integration/docs_generate_tests/test_docs_generate.py
+++ b/tests/integration/docs_generate_tests/test_docs_generate.py
@@ -463,6 +463,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             'full_refresh': None,
             'on_schema_change': 'ignore',
             'meta': {},
+            'unique_key': None
         }
         result.update(updates)
         return result
@@ -487,6 +488,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             'schema': None,
             'alias': None,
             'meta': {},
+            'unique_key': None
         }
         result.update(updates)
         return result
@@ -515,7 +517,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             'check_cols': 'all',
             'unique_key': 'id',
             'target_schema': None,
-            'meta': {},
+            'meta': {}
         }
         result.update(updates)
         return result

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -183,6 +183,7 @@ REQUIRED_BASE_KEYS = frozenset({
     'invocation_id',
     'modules',
     'flags',
+    'print'
 })
 
 REQUIRED_TARGET_KEYS = REQUIRED_BASE_KEYS | {'target'}
@@ -451,20 +452,20 @@ def test_resolve_specific(config, manifest_extended, redshift_adapter, get_inclu
     # macro_a exists, but default__macro_a and redshift__macro_a do not
     with pytest.raises(dbt.exceptions.CompilationException):
         ctx['adapter'].dispatch('macro_a').macro
-    
+
     # root namespace is always preferred, unless search order is explicitly defined in 'dispatch' config
     assert ctx['adapter'].dispatch('some_macro').macro is package_rs_macro
     assert ctx['adapter'].dispatch('some_macro', 'dbt').macro is package_rs_macro
     assert ctx['adapter'].dispatch('some_macro', 'root').macro is package_rs_macro
-    
+
     # override 'dbt' namespace search order, dispatch to 'root' first
     ctx['adapter'].config.dispatch = [{'macro_namespace': 'dbt', 'search_order': ['root', 'dbt']}]
     assert ctx['adapter'].dispatch('some_macro', macro_namespace = 'dbt').macro is package_rs_macro
-    
+
     # override 'dbt' namespace search order, dispatch to 'dbt' only
     ctx['adapter'].config.dispatch = [{'macro_namespace': 'dbt', 'search_order': ['dbt']}]
     assert ctx['adapter'].dispatch('some_macro', macro_namespace = 'dbt').macro is rs_macro
-    
+
     # override 'root' namespace search order, dispatch to 'dbt' first
     ctx['adapter'].config.dispatch = [{'macro_namespace': 'root', 'search_order': ['dbt', 'root']}]
     assert ctx['adapter'].dispatch('some_macro', macro_namespace = 'root').macro is rs_macro


### PR DESCRIPTION
* Add unique_key field to config sections where it is now expected as a result of core PR 4618.

* Remove duplicate key.

* Fix unit test bug introduced by merge of dbt-core PR 4701.

Co-authored-by: Mila Page <versusfacit@users.noreply.github.com>

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-redshift next" section.